### PR TITLE
database queries 

### DIFF
--- a/client/components/Attendance.js
+++ b/client/components/Attendance.js
@@ -5,6 +5,7 @@ export default class Attendance extends Component {
   constructor(props) {
     super(props)
     //this should be the
+    this.handleSubmit = this.handleSubmit.bind(this)
   }
   componentDidMount() {
     // const group = props.classId
@@ -25,10 +26,11 @@ export default class Attendance extends Component {
       <div>
         <h1>Attendance</h1>
         <h3>Students Online:</h3>
+        {/* So for now this is just going to be all students */}
         <ul id="attendance-list" />
         <h3>Class Roster</h3>
 
-        <form>
+        <form onSubmit={this.handleSubmit}>
           <input type="checkbox" className="student" />
           <p>Paul</p>
           <input type="checkbox" className="student" />

--- a/client/components/TeacherClassboard.js
+++ b/client/components/TeacherClassboard.js
@@ -6,6 +6,7 @@ import {default as StudentClassDashboard} from './studentClassDashboard'
 import {default as Attendance} from './Attendance'
 import {default as AssignmentView} from './TeacherAssignmentView'
 import {default as AssignmentViewByStudent} from './TeacherAssignmentByStudentView'
+import {getSingleCourseThunk, getCourseStudentsThunk} from '../store/course'
 
 export class TeacherClassboard extends Component {
   constructor(props) {
@@ -55,39 +56,54 @@ export class TeacherClassboard extends Component {
   async componentWillMount() {
     try {
       await this.props.getMyCourses(this.props.reduxState.user.me.id)
+
+      let courseIdFromPath = this.props.location.pathname.slice(
+        this.props.location.pathname.length - 1
+      )
+
+      await this.props.getSingleCourse(courseIdFromPath)
+
+      await this.props.getStudentsForThisCourse(courseIdFromPath)
     } catch (err) {
       console.log(err)
     }
   }
 
   render() {
+    console.log('On TeacherClassboard.js, the props are ', this.props)
     const courseList = this.props.reduxState.user.courses || []
     // const identification = this.props.location.state.number || null
     // const courseName = this.props.location.state.name
-    const coursename = this.props.reduxState.user.courses
+    // const coursename = this.props.reduxState.user.courses
+    const courseName = this.props.reduxState.course.single.courseName
     return (
       <div className="teacherClassBoard">
         <div className="classboardList">
-          {/* {courseName}: List of Students + Assignments + Grades */}
+          <b>{courseName}</b>
+
+          {this.props.reduxState.course.students.map((studentObject, index) => {
+            return (
+              <div>
+                {`Student ${index}: ` +
+                  studentObject.firstName +
+                  ' ' +
+                  studentObject.lastName +
+                  ' (' +
+                  studentObject.email +
+                  ')'}
+              </div>
+            )
+          })}
         </div>
 
         <div className="scheduleDashBox">
           <div className="classboardSchedule">
-            {courseList.length > 0 ? (
-              courseList.map((course, index) => {
-                return (
-                  <div key={index}>
-                    {course.courseSchedule
-                      .split('\n')
-                      .map((eachLine, index) => {
-                        return <div key={index}>{eachLine}</div>
-                      })}
-                    <br />
-                  </div>
-                )
-              })
+            {this.props.reduxState.course.single.courseSchedule ? (
+              this.props.reduxState.course.single.courseSchedule
+                .split('\n')
+                .map((eachLine, index) => <div key={index}>{eachLine}</div>)
             ) : (
-              <div>Loading...</div>
+              <div>No Schedule Available</div>
             )}
           </div>
 
@@ -103,6 +119,8 @@ export class TeacherClassboard extends Component {
                 courseIdInherited={`${this.props.location.pathname.charAt(
                   this.props.location.pathname.length - 1
                 )}`}
+                userInherited={this.props.reduxState.user.me}
+                courseObjectInherited={this.props.reduxState.course.single}
               />
             ) : (
               <div />
@@ -157,7 +175,10 @@ export class TeacherClassboard extends Component {
 
 const mapDispatchToProps = dispatch => {
   return {
-    getMyCourses: id => dispatch(getTeacherCoursesThunk(id))
+    getMyCourses: userId => dispatch(getTeacherCoursesThunk(userId)),
+    getSingleCourse: courseId => dispatch(getSingleCourseThunk(courseId)),
+    getStudentsForThisCourse: courseId =>
+      dispatch(getCourseStudentsThunk(courseId))
   }
 }
 const mapStateToProps = state => {

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -10,6 +10,7 @@ export {default as TeacherClassboard} from './TeacherClassboard'
 export {default as TeacherDash} from './TeacherDash'
 export {default as Attendance} from './Attendance'
 export {default as StudentDashboard} from './studentDashboard'
+
 export {default as studentClassDashboard} from './studentClassDashboard'
 export {default as TeacherDashboard} from './TeacherDashboard'
 export {

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -9,7 +9,7 @@ export {Login, Signup} from './auth-form'
 export {default as TeacherClassboard} from './TeacherClassboard'
 export {default as TeacherDash} from './TeacherDash'
 export {default as Attendance} from './Attendance'
-export {default as StudentDashboard} from './StudentDashboard'
+export {default as StudentDashboard} from './studentDashboard'
 export {default as studentClassDashboard} from './studentClassDashboard'
 export {default as TeacherDashboard} from './TeacherDashboard'
 export {

--- a/client/components/studentClassDashboard.js
+++ b/client/components/studentClassDashboard.js
@@ -23,6 +23,7 @@ export class studentClassDashboard extends React.Component {
   componentDidMount() {
     let path
     let courseId
+    let first
     if (this.props.location) {
       // if we got there through a URL (when we're a student)
       path = this.props.location.pathname
@@ -31,24 +32,52 @@ export class studentClassDashboard extends React.Component {
     } else {
       courseId = this.props.courseIdInherited
     }
-    const first = this.props.location.state.firstName
+    if (this.props.location) {
+      first = this.props.location.state.firstName
+    } else {
+      first = this.props.userInherited.firstName
+    }
+
     // let courseId = path.slice(path.length - 1)
-    let courseName = this.props.location.state.name
-    console.log('the props are ', this.props)
+
+    let courseName
+    if (this.props.location) {
+      // if we're logged in as a student
+      courseName = this.props.location.state.name
+    } else {
+      // if we're accessing it through the teacher classboard
+      courseName = this.props.courseObjectInherited.courseName
+    }
     this.props.getCourse(courseId)
-    const socket = io(`/${this.props.location.state.number}`)
+    let socket
+    if (this.props.location) {
+      socket = io(`/${this.props.location.state.number}`)
+    } else {
+      socket = io(`/${this.props.courseObjectInherited.id}`) // opening a socket on the course ID
+    }
+
     const input = document.getElementById('chat-input')
 
     // I just commented these lines out so that I could render from the teacher's perspective
 
     // socket.emit('login', {name: first, type: 'Student'})
     socket.emit('login', {name: first, type: first})
+
+    let firstNameForSocket // not const
+    if (this.props.location) {
+      // if we're actually viewing the component through the URL, which is what we do as a student
+      firstNameForSocket = this.props.location.state.firstName
+    } else {
+      // otherwise, if we're rendering it within the teacher classboard component
+      firstNameForSocket = this.props.userInherited.firstName // might also want last name in the future
+    }
+
     input.addEventListener('keypress', e => {
       if (e.key === 'Enter') {
         socket.emit('message', {
           message: e.target.value,
-          firstName: this.props.location.state.firstName,
-          type: 'Student'
+          firstName: firstNameForSocket, // changed to a dynamic variable instead of checking this.props.state.location, which may
+          type: 'Student' // or may not exist depending on how we render the component.
         })
         e.target.value = ''
       }
@@ -82,7 +111,7 @@ export class studentClassDashboard extends React.Component {
     // console.log('state course number ', this.props.location.state.number)
     // console.log('state course name ', this.props.location.state.name)
     // console.log('state course first ', this.props.location.state.firstName)
-    console.log('the props are ', this.props)
+    console.log('On studentClassDashboard.js, the props are ', this.props)
     let courseIntro = []
     let courseDetails = []
     if (
@@ -105,7 +134,17 @@ export class studentClassDashboard extends React.Component {
             return <div key={index}>{element}</div>
           })}
         </div>
-        <div className="liveLecture">Live Lecture</div>
+        <div className="liveLecture">
+          Live Lecture
+          {this.props.accountType === 'teacher' ? (
+            <div>
+              <button>Record</button>
+              <button>Poll (survey)</button>
+            </div>
+          ) : (
+            <div />
+          )}
+        </div>
         <div className="liveChat">
           <button className="chatButtonCreate" onClick={this.toggleForm}>
             Create a New Group
@@ -126,6 +165,16 @@ export class studentClassDashboard extends React.Component {
           <div id="message-main">
             <div id="chat-messages" />
             <input id="chat-input" type="text" overflow="auto" />
+            {this.props.accountType === 'teacher' ? (
+              <div>
+                <button>MuteAll</button>
+                <button>Mute Specific</button>
+                <button>Remove Message</button>
+                <button>Cancel Chat for student</button>
+              </div>
+            ) : (
+              <div />
+            )}
           </div>
         </div>
         <div className="moreClassInformationComponent">
@@ -157,7 +206,8 @@ export class studentClassDashboard extends React.Component {
 const mapStateToProps = state => {
   return {
     course: state.course.single,
-    accountType: state.user.me.accountType
+    accountType: state.user.me.accountType,
+    reduxState: state
   }
 }
 

--- a/client/store/course.js
+++ b/client/store/course.js
@@ -51,7 +51,7 @@ export const getSingleCourseThunk = courseId => {
 export const getCourseStudentsThunk = courseId => {
   return async dispatch => {
     try {
-      const {data} = await axios.get(`api/courses/students/${courseId}`)
+      const {data} = await axios.get(`/api/courses/students/${courseId}`) // the first slash is very important
       const students = data.filter(user => user.accountType === 'student')
       dispatch(getCourseStudents(students))
     } catch (err) {

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -73,7 +73,6 @@ export const getTeacherCoursesThunk = teacherId => {
   return async dispatch => {
     try {
       const {data} = await axios.get(`/api/users/teachers/courses/${teacherId}`)
-      console.log('the data returned from the thunk is ', data)
       dispatch(getTeacherCourses(data))
     } catch (error) {
       console.error(error.message)

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "start": "node server",
     "start-dev": "NODE_ENV='development' npm run build-client-watch & NODE_ENV='development' npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
-    "test": "NODE_ENV='test' mocha \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register",
-    "heroku-postbuild": "webpack -p"
+    "test": "NODE_ENV='test' mocha \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- No longer mapping over all schedules on the teacher classboard, because it’s supposed to be for a single class.  

- Instead, we fetch a single course object and use it in the teacherclassboard component as well as pass it down to the student classboard component as props.   

- Now rendering list of students at the top of the single classboard view

- Currently, I’m refactoring things so we that we don’t always get course number/id, etc. from the this.props.location object.  The thing is, this.props.location only exists if we’re rendering the component by accessing its route through the URL; if we’re just rendering it through the teacher classboard, then there isn’t any location attribute and so we need to pass down the course object from teacherclassboard as props in order to access values on it.  

- So I open a socket on the course ID, and if we’re actually viewing the component through the URL, which is what we do as a student, then we still set firstNameForSocket (which was declared as an empty variable) to be equal to this.props.location.state.firstName.  otherwise, we declare it to be this.props.userInherited.firstName (when we’re accessing it as a component within the teacherclassboard).  

- So I basically changed the firstName variable (what you see in the chat when you type something) to a dynamic variable instead of checking this.props.state.location, which may or may not exist depending on how we render the component.  

- Also added static (non-functioning) buttons - Record, MuteAll - In Chat, Mute Specific - In Chat, Remove Message, Cancel Chat for student, Poll (survey) - to the studentClassboard (it shouldn’t even be called studentClassboard, it should be called just classboard) component, and these buttons only render if the person is logged in as a teacher.  

- The first slash is very important when making an axios.get request in a thunk creator.  